### PR TITLE
Feature/add og service support

### DIFF
--- a/plugins/module_utils/network/ios/argspec/acls/acls.py
+++ b/plugins/module_utils/network/ios/argspec/acls/acls.py
@@ -216,6 +216,7 @@ class AclsArgs(object):  # pylint: disable=R0903
                                 },
                                 "remarks": {"elements": "str", "type": "list"},
                                 "sequence": {"type": "int"},
+                                "service_object_group": {"type": "str"},
                                 "source": {
                                     "options": {
                                         "address": {"type": "str"},

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -78,7 +78,8 @@ def _tmplt_access_list_entries(aces):
                 )
         elif aces.get("protocol"):
             command += " {protocol}".format(**aces)
-        if aces.get("service_object_group"):                                                                                                                                                                                                      command += " object-group {service_object_group}".format(**aces)
+        if aces.get("service_object_group"):
+            command += " object-group {service_object_group}".format(**aces)
         if aces.get("source"):
             command = source_destination_common_config(aces, command, "source")
         if aces.get("destination"):

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -78,6 +78,7 @@ def _tmplt_access_list_entries(aces):
                 )
         elif aces.get("protocol"):
             command += " {protocol}".format(**aces)
+        if aces.get("service_object_group"):                                                                                                                                                                                                      command += " object-group {service_object_group}".format(**aces)
         if aces.get("source"):
             command = source_destination_common_config(aces, command, "source")
         if aces.get("destination"):
@@ -287,6 +288,7 @@ class AclsTemplate(NetworkTemplate):
                         (\sevaluate\s(?P<evaluate>\S+))?
                         (\s(?P<protocol_num>\d+)\s)?
                         (\s*(?P<protocol>ahp|eigrp|esp|gre|icmp|igmp|ipinip|ipv6|ip|nos|ospf|pcp|pim|sctp|tcp|ip|udp))?
+                        (\sobject-group\s(?P<service_obj_grp>\S+))?
                         ((\s*(?P<source_any>any))|
                         (\s*object-group\s(?P<source_obj_grp>\S+))|
                         (\s*host\s(?P<source_host>\S+))|
@@ -340,6 +342,7 @@ class AclsTemplate(NetworkTemplate):
                                 "protocol": "{{ protocol }}",
                                 "protocol_number": "{{ protocol_num }}",
                                 "icmp_igmp_tcp_protocol": "{{ icmp_igmp_tcp_protocol }}",
+                                "service_object_group": "{{ service_obj_grp }}",
                                 "source": {
                                     "address": "{{ source_address }}",
                                     "ipv6_address": "{{ ipv6_source_address }}",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding the ability to specify an object group of services in the ACL settings.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
acls.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Now you can add object-group service when creating ACL rule.

To do this, it is enough to specify a new variable "service_object_group":
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: ACL_NAME
  acl_type: extended
  aces:
    - sequence: '10'
       grant: 'permit'
       service_object_group: 'OG_WITH_MANY_PORTS'
       source:
         object_group: 'OG_SOURCE_HOSTS'
       destination:
         object_group: 'OG_DESTINATION_HOSTS'
```
What actually translates into a command:
```
10 permit object-group OG_WITH_MANY_PORTS object-group OG_SOURCE_HOSTS object-group OG_DESTINATION_HOSTS
```