### PR TITLE
feature/Add-OG-service-support

### DIFF
--- a/docs/cisco.ios.ios_acls_module.rst
+++ b/docs/cisco.ios.ios_acls_module.rst
@@ -3155,6 +3155,24 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="4">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>service_object_group</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Service object-group for destination port.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>source</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/module_utils/network/ios/argspec/acls/acls.py
+++ b/plugins/module_utils/network/ios/argspec/acls/acls.py
@@ -216,6 +216,7 @@ class AclsArgs(object):  # pylint: disable=R0903
                                 },
                                 "remarks": {"elements": "str", "type": "list"},
                                 "sequence": {"type": "int"},
+                                "service_object_group": {"type": "str"},
                                 "source": {
                                     "options": {
                                         "address": {"type": "str"},

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -78,6 +78,8 @@ def _tmplt_access_list_entries(aces):
                 )
         elif aces.get("protocol"):
             command += " {protocol}".format(**aces)
+        if aces.get("service_object_group"):
+            command += " object-group {service_object_group}".format(**aces)
         if aces.get("source"):
             command = source_destination_common_config(aces, command, "source")
         if aces.get("destination"):
@@ -286,6 +288,7 @@ class AclsTemplate(NetworkTemplate):
                         (\s(?P<grant>deny|permit))
                         (\sevaluate\s(?P<evaluate>\S+))?
                         (\s(?P<protocol_num>\d+)\s)?
+                        (\sobject-group\s(?P<service_obj_grp>\S+))?
                         (\s*(?P<protocol>ahp|eigrp|esp|gre|icmp|igmp|ipinip|ipv6|ip|nos|ospf|pcp|pim|sctp|tcp|ip|udp))?
                         ((\s*(?P<source_any>any))|
                         (\s*object-group\s(?P<source_obj_grp>\S+))|
@@ -340,6 +343,7 @@ class AclsTemplate(NetworkTemplate):
                                 "protocol": "{{ protocol }}",
                                 "protocol_number": "{{ protocol_num }}",
                                 "icmp_igmp_tcp_protocol": "{{ icmp_igmp_tcp_protocol }}",
+                                "service_object_group": "{{ service_obj_grp }}",
                                 "source": {
                                     "address": "{{ source_address }}",
                                     "ipv6_address": "{{ ipv6_source_address }}",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding the ability to specify an object group of services in the ACL settings.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
acls.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Now you can add object-group service when creating ACL rule.

To do this, it is enough to specify a new variable "service_object_group":
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: ACL_NAME
  acl_type: extended
  aces:
    - sequence: '10'
       grant: 'permit'
       service_object_group: 'OG_WITH_MANY_PORTS'
       source:
         object_group: 'OG_SOURCE_HOSTS'
       destination:
         object_group: 'OG_DESTINATION_HOSTS'
```
What actually translates into a command:
```
ip access-list extended ACL_NAME
 10 permit object-group OG_WITH_MANY_PORTS object-group OG_SOURCE_HOSTS object-group OG_DESTINATION_HOSTS
```